### PR TITLE
Distance from weaviate: smaller distance is higher similarity

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -591,8 +591,8 @@ class Docs(BaseModel, arbitrary_types_allowed=True, smart_union=True):
 
             # matches_with_score is a list of tuples (doc, score)
             # fetch all the scores in a list, sort them in descending order
-            scores = sorted([m[1] for m in matches_with_score], reverse=True)
-            matches_with_score = sorted(matches_with_score, key=lambda tup: tup[1], reverse=True)
+            scores = sorted([m[1] for m in matches_with_score], reverse=False)
+            matches_with_score = sorted(matches_with_score, key=lambda tup: tup[1], reverse=False)
             matches = [match_with_score[0] for match_with_score in matches_with_score]
 
             for m, score in zip(matches[:k], scores[:k]):


### PR DESCRIPTION
WIP: don't merge

Sort weaviate distance in ascending order.
In all cases, larger distance values indicate lower similarity. Conversely, smaller distance values indicate higher similarity.